### PR TITLE
breaking: make `Line::KeyVal` take a struct instead of being a tuple

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod lines;
 use std::{collections::HashMap, fs::read_to_string, io::Result, path::PathBuf};
 
 // Just re-exporting to use as a standalone parser
-pub use lines::{Line, Lines};
+pub use lines::{KeyVal, Line, Lines};
 
 #[derive(Debug)]
 pub struct Zenv {

--- a/tests/line.rs
+++ b/tests/line.rs
@@ -1,10 +1,17 @@
 use zenv::*;
 
+pub fn parse(line: &str) -> Option<(String, String)> {
+    match Line::from(line) {
+        Line::KeyVal(KeyVal { k, v, .. }) => Some((k, v)),
+        _ => None,
+    }
+}
+
 #[test]
 fn basic() {
-    let res = Line::from("BASIC=basic");
+    let res = parse("BASIC=basic").unwrap();
 
-    assert_eq!(res, Line::KeyVal("BASIC".to_string(), "basic".to_string()))
+    assert_eq!(res, ("BASIC".to_string(), "basic".to_string()))
 }
 
 #[test]
@@ -16,28 +23,28 @@ fn empty_line() {
 
 #[test]
 fn empty_value() {
-    let res = Line::from("EMPTY=");
+    let res = parse("EMPTY=").unwrap();
 
-    assert_eq!(res, Line::KeyVal("EMPTY".to_string(), "".to_string()))
+    assert_eq!(res, ("EMPTY".to_string(), "".to_string()))
 }
 
 #[test]
 fn single_quotes() {
-    let res = Line::from("SINGLE_QUOTES='single_quotes'");
+    let res = parse("SINGLE_QUOTES='single_quotes'").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal("SINGLE_QUOTES".to_string(), "single_quotes".to_string())
+        ("SINGLE_QUOTES".to_string(), "single_quotes".to_string())
     )
 }
 
 #[test]
 fn single_quotes_spaced() {
-    let res = Line::from("SINGLE_QUOTES_SPACED='    single_quotes_spaced    '");
+    let res = parse("SINGLE_QUOTES_SPACED='    single_quotes_spaced    '").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "SINGLE_QUOTES_SPACED".to_string(),
             "    single_quotes_spaced    ".to_string()
         )
@@ -46,21 +53,21 @@ fn single_quotes_spaced() {
 
 #[test]
 fn double_quotes() {
-    let res = Line::from("DOUBLE_QUOTES=\"double_quotes\"");
+    let res = parse("DOUBLE_QUOTES=\"double_quotes\"").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal("DOUBLE_QUOTES".to_string(), "double_quotes".to_string())
+        ("DOUBLE_QUOTES".to_string(), "double_quotes".to_string())
     )
 }
 
 #[test]
 fn double_quotes_spaced() {
-    let res = Line::from("DOUBLE_QUOTES_SPACED=\"    double_quotes_spaced    \"");
+    let res = parse("DOUBLE_QUOTES_SPACED=\"    double_quotes_spaced    \"").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "DOUBLE_QUOTES_SPACED".to_string(),
             "    double_quotes_spaced    ".to_string()
         )
@@ -69,11 +76,11 @@ fn double_quotes_spaced() {
 
 #[test]
 fn expand_newlines() {
-    let res = Line::from(r#"EXPAND_NEWLINES="expand\nnew\nlines""#);
+    let res = parse(r#"EXPAND_NEWLINES="expand\nnew\nlines""#).unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "EXPAND_NEWLINES".to_string(),
             "expand\nnew\nlines".to_string()
         )
@@ -82,11 +89,11 @@ fn expand_newlines() {
 
 #[test]
 fn escaped_newlines_dquote() {
-    let res = Line::from(r#"ESCAPED_NEWLINES_DQUOTE="escaped\\nnew\\nlines""#);
+    let res = parse(r#"ESCAPED_NEWLINES_DQUOTE="escaped\\nnew\\nlines""#).unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "ESCAPED_NEWLINES_DQUOTE".to_string(),
             "escaped\\nnew\\nlines".to_string()
         )
@@ -95,11 +102,11 @@ fn escaped_newlines_dquote() {
 
 #[test]
 fn escaped_newlines_squote() {
-    let res = Line::from("ESCAPED_NEWLINES_SQUOTE='escaped\\nnew\\nlines'");
+    let res = parse("ESCAPED_NEWLINES_SQUOTE='escaped\\nnew\\nlines'").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "ESCAPED_NEWLINES_SQUOTE".to_string(),
             "escaped\\nnew\\nlines".to_string()
         )
@@ -108,11 +115,11 @@ fn escaped_newlines_squote() {
 
 #[test]
 fn dont_expand_unquoted() {
-    let res = Line::from("DONT_EXPAND_UNQUOTED=dont\nexpand\nnew\nlines");
+    let res = parse("DONT_EXPAND_UNQUOTED=dont\nexpand\nnew\nlines").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "DONT_EXPAND_UNQUOTED".to_string(),
             "dont\\nexpand\\nnew\\nlines".to_string()
         )
@@ -121,11 +128,11 @@ fn dont_expand_unquoted() {
 
 #[test]
 fn dont_expand_squoted() {
-    let res = Line::from("DONT_EXPAND_SQUOTED='dont\nexpand\nnew\nlines'");
+    let res = parse("DONT_EXPAND_SQUOTED='dont\nexpand\nnew\nlines'").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "DONT_EXPAND_SQUOTED".to_string(),
             "dont\\nexpand\\nnew\\nlines".to_string()
         )
@@ -134,21 +141,18 @@ fn dont_expand_squoted() {
 
 #[test]
 fn equal_signs() {
-    let res = Line::from("EQUAL_SIGNS=equals==");
+    let res = parse("EQUAL_SIGNS=equals==").unwrap();
 
-    assert_eq!(
-        res,
-        Line::KeyVal("EQUAL_SIGNS".to_string(), "equals==".to_string())
-    )
+    assert_eq!(res, ("EQUAL_SIGNS".to_string(), "equals==".to_string()))
 }
 
 #[test]
 fn retain_inner_quotes() {
-    let res = Line::from(r#"RETAIN_INNER_QUOTES={"foo": "bar"}"#);
+    let res = parse(r#"RETAIN_INNER_QUOTES={"foo": "bar"}"#).unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_INNER_QUOTES".to_string(),
             r#"{"foo": "bar"}"#.to_string()
         )
@@ -157,11 +161,11 @@ fn retain_inner_quotes() {
 
 #[test]
 fn retain_leading_dquote() {
-    let res = Line::from("RETAIN_LEADING_DQUOTE=\"retained_dquote");
+    let res = parse("RETAIN_LEADING_DQUOTE=\"retained_dquote").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_LEADING_DQUOTE".to_string(),
             "\"retained_dquote".to_string()
         )
@@ -170,11 +174,11 @@ fn retain_leading_dquote() {
 
 #[test]
 fn retain_leading_dquote_with_comment() {
-    let res = Line::from("RETAIN_LEADING_DQUOTE_COMMENT=\"retained_dquote comment # comment");
+    let res = parse("RETAIN_LEADING_DQUOTE_COMMENT=\"retained_dquote comment # comment").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_LEADING_DQUOTE_COMMENT".to_string(),
             "\"retained_dquote comment".to_string()
         )
@@ -183,11 +187,11 @@ fn retain_leading_dquote_with_comment() {
 
 #[test]
 fn retain_leading_squote() {
-    let res = Line::from("RETAIN_LEADING_SQUOTE='retained_squote");
+    let res = parse("RETAIN_LEADING_SQUOTE='retained_squote").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_LEADING_SQUOTE".to_string(),
             "'retained_squote".to_string()
         )
@@ -196,11 +200,11 @@ fn retain_leading_squote() {
 
 #[test]
 fn retain_leading_squote_with_comment() {
-    let res = Line::from("RETAIN_LEADING_SQUOTE_COMMENT='retained_squote comment # comment");
+    let res = parse("RETAIN_LEADING_SQUOTE_COMMENT='retained_squote comment # comment").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_LEADING_SQUOTE_COMMENT".to_string(),
             "'retained_squote comment".to_string()
         )
@@ -209,11 +213,11 @@ fn retain_leading_squote_with_comment() {
 
 #[test]
 fn retain_trailing_dquote() {
-    let res = Line::from("RETAIN_TRAILING_DQUOTE=retained_dquote\"");
+    let res = parse("RETAIN_TRAILING_DQUOTE=retained_dquote\"").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_TRAILING_DQUOTE".to_string(),
             "retained_dquote\"".to_string()
         )
@@ -222,11 +226,11 @@ fn retain_trailing_dquote() {
 
 #[test]
 fn retain_trailing_squote() {
-    let res = Line::from("RETAIN_TRAILING_SQUOTE=retained_squote'");
+    let res = parse("RETAIN_TRAILING_SQUOTE=retained_squote'").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_TRAILING_SQUOTE".to_string(),
             "retained_squote'".to_string()
         )
@@ -235,11 +239,11 @@ fn retain_trailing_squote() {
 
 #[test]
 fn retain_inner_quotes_as_string() {
-    let res = Line::from(r#"RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'"#);
+    let res = parse(r#"RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'"#).unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "RETAIN_INNER_QUOTES_AS_STRING".to_string(),
             r#"{"foo": "bar"}"#.to_string()
         )
@@ -248,11 +252,11 @@ fn retain_inner_quotes_as_string() {
 
 #[test]
 fn trim_space_from_unquoted() {
-    let res = Line::from("TRIM_SPACE_FROM_UNQUOTED=    some spaced out string");
+    let res = parse("TRIM_SPACE_FROM_UNQUOTED=    some spaced out string").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "TRIM_SPACE_FROM_UNQUOTED".to_string(),
             "some spaced out string".to_string()
         )
@@ -268,12 +272,9 @@ fn just_space() {
 
 #[test]
 fn spaced_key() {
-    let res = Line::from("    SPACED_KEY = spaced_key");
+    let res = parse("    SPACED_KEY = spaced_key").unwrap();
 
-    assert_eq!(
-        res,
-        Line::KeyVal("SPACED_KEY".to_string(), "spaced_key".to_string())
-    )
+    assert_eq!(res, ("SPACED_KEY".to_string(), "spaced_key".to_string()))
 }
 
 #[test]
@@ -285,22 +286,22 @@ fn comment_basic() {
 
 #[test]
 fn comment_at_end_unquoted() {
-    let res = Line::from("COMMENT_AT_END=comment_at_end # this is the comment");
+    let res = parse("COMMENT_AT_END=comment_at_end # this is the comment").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal("COMMENT_AT_END".to_string(), "comment_at_end".to_string())
+        ("COMMENT_AT_END".to_string(), "comment_at_end".to_string())
     )
 }
 
 #[test]
 fn comment_at_end_squote() {
     let res =
-        Line::from("COMMENT_AT_END_SQUOTE='comment_at_##_end_squote_#' # this is the comment");
+        parse("COMMENT_AT_END_SQUOTE='comment_at_##_end_squote_#' # this is the comment").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "COMMENT_AT_END_SQUOTE".to_string(),
             "comment_at_##_end_squote_#".to_string()
         )
@@ -309,11 +310,12 @@ fn comment_at_end_squote() {
 
 #[test]
 fn comment_at_end_dquote() {
-    let res = Line::from("COMMENT_AT_END_DQUOTE=\"comment_at_#_end_dquote\" # this is the comment");
+    let res =
+        parse("COMMENT_AT_END_DQUOTE=\"comment_at_#_end_dquote\" # this is the comment").unwrap();
 
     assert_eq!(
         res,
-        Line::KeyVal(
+        (
             "COMMENT_AT_END_DQUOTE".to_string(),
             "comment_at_#_end_dquote".to_string()
         )


### PR DESCRIPTION
Before
```rust
pub enum Line {
    KeyVal(String, String),
    Empty,
}
```

After
```rust
pub enum Quote {
    Single,
    Double,
    No,
}

pub struct KeyVal {
    pub k: String,
    pub v: String,
    pub q: Quote,
}

pub enum Line {
    KeyVal(KeyVal),
    Empty,
}
```