### PR TITLE
feat: `zenv!()` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,3 +57,16 @@ impl Zenv {
         Ok(())
     }
 }
+
+#[macro_export]
+macro_rules! zenv {
+    () => {
+        zenv::Zenv::new(".env", false).configure().ok()
+    };
+    ($path:expr) => {
+        zenv::Zenv::new($path, false).configure().ok()
+    };
+    ($path:expr, $expand:expr) => {
+        zenv::Zenv::new($path, $expand).configure().ok()
+    };
+}

--- a/tests/zenv.rs
+++ b/tests/zenv.rs
@@ -1,4 +1,4 @@
-use zenv::Zenv;
+use zenv::{zenv, Zenv};
 
 #[test]
 fn zenv_basic() {
@@ -36,4 +36,27 @@ fn zenv_expanded() {
 
     assert_eq!(z.get("NO_SYSTEM_VAR").unwrap(), "_dont_exist");
     assert_ne!(z.get("SYSTEM_VAR").unwrap(), "_exist");
+}
+
+#[test]
+fn zenv_macro_basic() {
+    use std::env::var_os;
+
+    zenv!("tests/.env.basic");
+
+    assert_eq!(var_os("BASIC").unwrap(), "basic");
+    assert_eq!(var_os("EMPTY").unwrap(), "");
+    assert_eq!(var_os("SINGLE_QUOTES").unwrap(), "single_quotes");
+    assert_eq!(var_os("DOUBLE_QUOTES").unwrap(), "double_quotes");
+}
+
+#[test]
+fn zenv_macro_expanded() {
+    use std::env::var_os;
+
+    zenv!("tests/.env.expanded", true);
+
+    assert_eq!(var_os("BASIC").unwrap(), "basic");
+    assert_eq!(var_os("EXPANDED").unwrap(), "basic-expanded");
+    assert_eq!(var_os("DOUBLE_EXPANDED").unwrap(), "basic-basic-expanded");
 }


### PR DESCRIPTION
Instead of writing this
```rust

fn main() {
    zenv::Zenv::new(".env", false).configure().ok()
}
```

You can now write this
```rust
fn main() {
    zenv::zenv!()
}
```